### PR TITLE
Reference demo dashboard in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,8 @@ See [Contribute](https://github.com/grafadruid/druid-grafana/blob/master/CONTRIB
 Where `$VERSION` is for instance `1.0.0` and `$YOUR_PLUGIN_DIR` is for instance `/var/lib/grafana/plugins`
 
 (Source: https://grafana.com/docs/grafana/latest/plugins/installation/)
+
+## Usage
+
+You can try out various advanced features of the plugin by importing the [demo dashboard](https://github.com/grafadruid/druid-grafana/blob/master/dashboard.json) and running it against the Wikipedia dataset used in the [Druid quickstart tutorial](https://druid.apache.org/docs/latest/tutorials/index.html#step-4-load-data).
+


### PR DESCRIPTION
Point users at the demo dashboard that's being shipped with the plugin as discussed in #35. 