### PR TITLE
support log panel in explore

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 - Query builder UI: done
 - Alerting: done
 - Query backend: done (sql, timeseries, topn, groupby, timeboundary, segmentmetadata, datasourcemetadata, scan, search)
-- Explore advanced support: done (standard: done, advanced: todo? any specific need?)
+- Explore advanced support: done (standard: done, logs: done, advanced: todo? any specific need?)
 - Variables support: done (Grafana global variables replacement, query variables)
 - Extensions support: todo
 

--- a/pkg/druid.go
+++ b/pkg/druid.go
@@ -734,8 +734,7 @@ func (ds *druidDatasource) prepareResponse(resp *druidResponse, settings map[str
 	}
 	if format == "log" {
 		for ic, c := range resp.Columns {
-			var ff []string
-			ff = make([]string, 0)
+			ff := make([]string, 0)
 			if c.Type == "string" && c.Name == "message" {
 				for _, r := range resp.Rows {
 					if r[ic] == nil {

--- a/pkg/druid.go
+++ b/pkg/druid.go
@@ -725,6 +725,7 @@ func (ds *druidDatasource) prepareResponse(resp *druidResponse, settings map[str
 	// refactor: probably some method that returns a container (make([]whattypeever, 0)) and its related appender func based on column type)
 	response := backend.DataResponse{}
 	frame := data.NewFrame("response")
+  frame.SetMeta(&data.FrameMeta{PreferredVisualization: data.VisTypeLogs})
 	hideEmptyColumns, _ := settings["hideEmptyColumns"].(bool)
 	for ic, c := range resp.Columns {
 		var ff interface{}

--- a/pkg/druid.go
+++ b/pkg/druid.go
@@ -727,26 +727,26 @@ func (ds *druidDatasource) prepareResponse(resp *druidResponse, settings map[str
 	frame := data.NewFrame("response")
 	hideEmptyColumns, _ := settings["hideEmptyColumns"].(bool)
 	format, ok := settings["format"]
-  if !ok {
-    format = "long"
-  } else {
-    format = format.(string)
-  }
-  if format == "log" {
-    for ic, c := range resp.Columns {
-      var ff []string
-      ff = make([]string, 0)
-      if c.Type == "string" && c.Name == "message" {
-        for _, r := range resp.Rows {
-          if r[ic] == nil {
-            r[ic] = ""
-          }
-          ff = append(ff, r[ic].(string))
-        }
-        frame.Fields = append(frame.Fields, data.NewField("____message", nil, ff))
-      }
-    }
-  }
+	if !ok {
+		format = "long"
+	} else {
+		format = format.(string)
+	}
+	if format == "log" {
+		for ic, c := range resp.Columns {
+			var ff []string
+			ff = make([]string, 0)
+			if c.Type == "string" && c.Name == "message" {
+				for _, r := range resp.Rows {
+					if r[ic] == nil {
+						r[ic] = ""
+					}
+					ff = append(ff, r[ic].(string))
+				}
+				frame.Fields = append(frame.Fields, data.NewField("____message", nil, ff))
+			}
+		}
+	}
 	for ic, c := range resp.Columns {
 		var ff interface{}
 		columnIsEmpty := true

--- a/pkg/druid.go
+++ b/pkg/druid.go
@@ -725,7 +725,6 @@ func (ds *druidDatasource) prepareResponse(resp *druidResponse, settings map[str
 	// refactor: probably some method that returns a container (make([]whattypeever, 0)) and its related appender func based on column type)
 	response := backend.DataResponse{}
 	frame := data.NewFrame("response")
-  frame.SetMeta(&data.FrameMeta{PreferredVisualization: data.VisTypeLogs})
 	hideEmptyColumns, _ := settings["hideEmptyColumns"].(bool)
 	for ic, c := range resp.Columns {
 		var ff interface{}
@@ -803,11 +802,14 @@ func (ds *druidDatasource) prepareResponse(resp *druidResponse, settings map[str
 		}
 		frame.Fields = append(frame.Fields, data.NewField(c.Name, nil, ff))
 	}
-	if format, ok := settings["format"]; ok && format.(string) == "wide" && len(frame.Fields) > 0 {
+	format, ok := settings["format"]
+	if ok && format.(string) == "wide" && len(frame.Fields) > 0 {
 		f, err := data.LongToWide(frame, nil)
 		if err == nil {
 			frame = f
 		}
+	} else if format.(string) == "log" && len(frame.Fields) > 0 {
+		frame.SetMeta(&data.FrameMeta{PreferredVisualization: data.VisTypeLogs})
 	}
 	response.Frames = append(response.Frames, frame)
 	return response, nil

--- a/pkg/druid.go
+++ b/pkg/druid.go
@@ -742,6 +742,8 @@ func (ds *druidDatasource) prepareResponse(resp *druidResponse, settings map[str
 					}
 					ff = append(ff, r[ic].(string))
 				}
+        // log message is the first string field. set a new field so the original message field
+        // can still be displayed when showing detected fields
 				frame.Fields = append(frame.Fields, data.NewField("____message", nil, ff))
 			}
 		}

--- a/src/DruidDataSource.ts
+++ b/src/DruidDataSource.ts
@@ -1,10 +1,9 @@
-import { DataSourceInstanceSettings, DataQueryRequest, DataQueryResponse, QueryResultMeta } from '@grafana/data';
+import { DataSourceInstanceSettings } from '@grafana/data';
 import { MetricFindValue } from '@grafana/data';
 import { DataSourceWithBackend } from '@grafana/runtime';
 import { getTemplateSrv } from '@grafana/runtime';
 import { DruidSettings, DruidQuery } from './types';
 import { cloneDeepWith } from 'lodash';
-import { Observable } from 'rxjs';
 
 export class DruidDataSource extends DataSourceWithBackend<DruidQuery, DruidSettings> {
   constructor(instanceSettings: DataSourceInstanceSettings<DruidSettings>) {
@@ -18,20 +17,6 @@ export class DruidDataSource extends DataSourceWithBackend<DruidQuery, DruidSett
       } else {
         return undefined;
       }
-    });
-  }
-  query(request: DataQueryRequest<DruidQuery>): Observable<DataQueryResponse> {
-    var response = super.query(request);
-    return new Observable<DataQueryResponse>((subscriber) => {
-      response.subscribe((next) => {
-        next.data.forEach((datum) => {
-          if (datum.meta === undefined) {
-            datum.meta = {} as QueryResultMeta;
-          }
-          datum.meta.preferredVisualisationType = 'logs';
-        });
-        subscriber.next(next);
-      });
     });
   }
   async metricFindQuery(query: DruidQuery, options?: any): Promise<MetricFindValue[]> {

--- a/src/DruidDataSource.ts
+++ b/src/DruidDataSource.ts
@@ -1,9 +1,10 @@
-import { DataSourceInstanceSettings } from '@grafana/data';
+import { DataSourceInstanceSettings, DataQueryRequest, DataQueryResponse, QueryResultMeta } from '@grafana/data';
 import { MetricFindValue } from '@grafana/data';
 import { DataSourceWithBackend } from '@grafana/runtime';
 import { getTemplateSrv } from '@grafana/runtime';
 import { DruidSettings, DruidQuery } from './types';
 import { cloneDeepWith } from 'lodash';
+import { Observable } from 'rxjs';
 
 export class DruidDataSource extends DataSourceWithBackend<DruidQuery, DruidSettings> {
   constructor(instanceSettings: DataSourceInstanceSettings<DruidSettings>) {
@@ -17,6 +18,20 @@ export class DruidDataSource extends DataSourceWithBackend<DruidQuery, DruidSett
       } else {
         return undefined;
       }
+    });
+  }
+  query(request: DataQueryRequest<DruidQuery>): Observable<DataQueryResponse> {
+    var response = super.query(request);
+    return new Observable<DataQueryResponse>((subscriber) => {
+      response.subscribe((next) => {
+        next.data.forEach((datum) => {
+          if (datum.meta === undefined) {
+            datum.meta = {} as QueryResultMeta;
+          }
+          datum.meta.preferredVisualisationType = 'logs';
+        });
+        subscriber.next(next);
+      });
     });
   }
   async metricFindQuery(query: DruidQuery, options?: any): Promise<MetricFindValue[]> {

--- a/src/configuration/QuerySettings/DruidQueryLogSettings.tsx
+++ b/src/configuration/QuerySettings/DruidQueryLogSettings.tsx
@@ -1,0 +1,78 @@
+import React, { PureComponent, ChangeEvent } from 'react';
+import { FieldSet, LegacyForms, Collapse } from '@grafana/ui';
+import { QuerySettingsProps } from './types';
+
+const { FormField } = LegacyForms;
+
+export class DruidQueryLogSettings extends PureComponent<QuerySettingsProps> {
+  constructor(props: QuerySettingsProps) {
+    super(props);
+
+    const { settings } = this.props.options;
+
+    if (settings.logColumnTime === undefined) {
+      settings.logColumnTime = '__time';
+    }
+    if (settings.logColumnLevel === undefined) {
+      settings.logColumnLevel = 'level';
+    }
+    if (settings.logColumnMessage === undefined) {
+      settings.logColumnMessage = 'message';
+    }
+  }
+
+  onInputChanged = (event: ChangeEvent<HTMLInputElement>) => {
+    const { options, onOptionsChange } = this.props;
+    const { settings } = options;
+    const value = event.target.value;
+    switch (event.target.name) {
+      case 'time': {
+        settings.logColumnTime = value;
+        break;
+      }
+      case 'level': {
+        settings.logColumnLevel = value;
+        break;
+      }
+      case 'message': {
+        settings.logColumnMessage = value;
+        break;
+      }
+    }
+    onOptionsChange({ ...options, settings: settings });
+  };
+
+  render() {
+    const { settings } = this.props.options;
+    return (
+      <Collapse label="Log column settings" isOpen={true}>
+        <FieldSet>
+          <FormField
+            label="Time"
+            name="time"
+            type="text"
+            tooltip="Set the column logs will use as the time for each row"
+            value={settings.logColumnTime}
+            onChange={this.onInputChanged}
+          />
+          <FormField
+            label="Level"
+            name="level"
+            type="text"
+            tooltip="Set the column logs will use as the level for each row"
+            value={settings.logColumnLevel}
+            onChange={this.onInputChanged}
+          />
+          <FormField
+            label="Message"
+            name="message"
+            type="text"
+            tooltip="Set the column logs will use as the message for each row"
+            value={settings.logColumnMessage}
+            onChange={this.onInputChanged}
+          />
+        </FieldSet>
+      </Collapse>
+    );
+  }
+}

--- a/src/configuration/QuerySettings/DruidQueryResponseSettings.tsx
+++ b/src/configuration/QuerySettings/DruidQueryResponseSettings.tsx
@@ -1,5 +1,5 @@
 import React, { PureComponent, ChangeEvent } from 'react';
-import { InlineFieldRow, InlineField, InlineSwitch, Select } from '@grafana/ui';
+import { InlineFieldRow, InlineField, InlineSwitch, Select, Input, Collapse } from '@grafana/ui';
 import { SelectableValue } from '@grafana/data';
 import { QuerySettingsProps } from './types';
 
@@ -63,6 +63,21 @@ export class DruidQueryResponseSettings extends PureComponent<QuerySettingsProps
             />
           </InlineField>
         </InlineFieldRow>
+        {settings.format === 'log' && (
+          <Collapse label="Log Settings" isOpen={true}>
+            <InlineFieldRow>
+              <InlineField label="Time column" tooltip="Use this column as the time for logs">
+                <Input value={'__time'} />
+              </InlineField>
+              <InlineField label="Level column" tooltip="Use this column as the level for logs">
+                <Input value={'level'} />
+              </InlineField>
+              <InlineField label="Message column" tooltip="Use this column as the message for logs">
+                <Input value={'message'} />
+              </InlineField>
+            </InlineFieldRow>
+          </Collapse>
+        )}
         <InlineFieldRow>
           <InlineField
             label="Hide empty columns"

--- a/src/configuration/QuerySettings/DruidQueryResponseSettings.tsx
+++ b/src/configuration/QuerySettings/DruidQueryResponseSettings.tsx
@@ -20,6 +20,7 @@ export class DruidQueryResponseSettings extends PureComponent<QuerySettingsProps
   formatSelectOptions: Array<SelectableValue<string>> = [
     { label: 'Long', value: 'long' },
     { label: 'Wide', value: 'wide' },
+    { label: 'Log', value: 'log' },
   ];
 
   selectFormatOptionByValue = (value?: string): SelectableValue<string> | undefined => {

--- a/src/configuration/QuerySettings/DruidQueryResponseSettings.tsx
+++ b/src/configuration/QuerySettings/DruidQueryResponseSettings.tsx
@@ -1,7 +1,8 @@
 import React, { PureComponent, ChangeEvent } from 'react';
-import { InlineFieldRow, InlineField, InlineSwitch, Select, Input, Collapse } from '@grafana/ui';
+import { InlineFieldRow, InlineField, InlineSwitch, Select } from '@grafana/ui';
 import { SelectableValue } from '@grafana/data';
 import { QuerySettingsProps } from './types';
+import { DruidQueryLogSettings } from './DruidQueryLogSettings';
 
 export class DruidQueryResponseSettings extends PureComponent<QuerySettingsProps> {
   constructor(props: QuerySettingsProps) {
@@ -63,21 +64,7 @@ export class DruidQueryResponseSettings extends PureComponent<QuerySettingsProps
             />
           </InlineField>
         </InlineFieldRow>
-        {settings.format === 'log' && (
-          <Collapse label="Log Settings" isOpen={true}>
-            <InlineFieldRow>
-              <InlineField label="Time column" tooltip="Use this column as the time for logs">
-                <Input value={'__time'} />
-              </InlineField>
-              <InlineField label="Level column" tooltip="Use this column as the level for logs">
-                <Input value={'level'} />
-              </InlineField>
-              <InlineField label="Message column" tooltip="Use this column as the message for logs">
-                <Input value={'message'} />
-              </InlineField>
-            </InlineFieldRow>
-          </Collapse>
-        )}
+        {settings.format === 'log' && <DruidQueryLogSettings {...this.props} />}
         <InlineFieldRow>
           <InlineField
             label="Hide empty columns"

--- a/src/configuration/QuerySettings/index.ts
+++ b/src/configuration/QuerySettings/index.ts
@@ -2,3 +2,4 @@ export { DruidQueryDefaultSettings } from './DruidQueryDefaultSettings';
 export { DruidQuerySettings } from './DruidQuerySettings';
 export { DruidQueryContextSettings } from './DruidQueryContextSettings';
 export { DruidQueryResponseSettings } from './DruidQueryResponseSettings';
+export { DruidQueryLogSettings } from './DruidQueryLogSettings';

--- a/src/configuration/QuerySettings/types.ts
+++ b/src/configuration/QuerySettings/types.ts
@@ -7,6 +7,9 @@ export interface QuerySettings {
   format?: string;
   contextParameters?: QueryContextParameter[];
   hideEmptyColumns?: boolean;
+  logColumnTime?: string;
+  logColumnLevel?: string;
+  logColumnMessage?: string;
 }
 export interface QuerySettingsOptions {
   settings: QuerySettings;

--- a/src/plugin.json
+++ b/src/plugin.json
@@ -5,6 +5,7 @@
   "metrics": true,
   "backend": true,
   "alerting": true,
+  "logs": true,
   "executable": "grafadruid-druid-datasource",
   "info": {
     "description": "Connects Grafana to Druid",


### PR DESCRIPTION
addresses issue #46 to return results in a way that works with the log view.

mostly this required making sure whatever field we want to use for the message is returned as the first string field in the array. beyond that it's some minor things to make the time and level fields configurable (if there is more than one time, choose the time; if there is no `level` field, pick one and rename it `level`).

does not use labels since those are on the field rather than the row so doesn't appear to be a good way to use them here.