### PR TITLE
Refactor toolbox

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ workflows:
       - build
 
 executors:
-  default_exec:  # declares a reusable executor
+  default_exec: # declares a reusable executor
     docker:
       - image: srclosson/grafana-plugin-ci-alpine:latest
   e2e_exec:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ name: Release
 on:
   push:
     tags:
-      - 'v*.*.*'  # Run workflow on version tags, e.g. v1.0.0.
+      - 'v*.*.*' # Run workflow on version tags, e.g. v1.0.0.
 
 jobs:
   release:
@@ -82,7 +82,7 @@ jobs:
         run: yarn run grafana-toolkit plugin:sign
         env:
           # yamllint disable-line rule:line-length
-          GRAFANA_API_KEY: ${{ secrets.GRAFANA_API_KEY }}  # Requires a Grafana API key from Grafana.com.
+          GRAFANA_API_KEY: ${{ secrets.GRAFANA_API_KEY }} # Requires a Grafana API key from Grafana.com.
 
       - name: Get plugin metadata
         id: metadata

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,3 @@
 nodejs 14.16.0
 golang 1.16.2
+python 3.9.2

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -1,0 +1,8 @@
+---
+extends: default
+
+ignore: |
+  node_modules
+
+rules:
+  comments: disable

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,5 +23,5 @@ test_script:
 
 # Run the build
 build_script:
-  - yarn dev  # This will also run prettier!
-  - yarn build  # make sure both scripts work
+  - yarn dev # This will also run prettier!
+  - yarn build # make sure both scripts work

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -122,8 +122,8 @@ services:
 
   toolbox:
     build:
-      context: .
-      dockerfile: ./toolbox/Dockerfile
+      context: ..
+      dockerfile: ./docker/toolbox/Dockerfile
     depends_on:
       - coordinator
     restart: on-failure

--- a/docker/provisioning/post-index-task
+++ b/docker/provisioning/post-index-task
@@ -1,0 +1,176 @@
+#!/usr/bin/env python
+
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import argparse
+import base64
+import json
+import re
+import sys
+import time
+import urllib.request, urllib.error, urllib.parse
+import urllib.parse
+
+def read_task_file(args):
+  with open(args.file, 'r') as f:
+    contents = f.read()
+    # We don't use the parsed data, but we want to throw early if it's invalid
+    try:
+      json.loads(contents)
+    except Exception as e:
+      sys.stderr.write('Invalid JSON in task file "{0}": {1}\n'.format(args.file, repr(e)))
+      sys.exit(1)
+    return contents
+
+def add_basic_auth_header(args, req):
+  if (args.user is not None):
+    basic_auth_encoded = base64.b64encode('%s:%s' % (args.user, args.password))
+    req.add_header("Authorization", "Basic %s" % basic_auth_encoded)
+
+# Keep trying until timeout_at, maybe die then
+def post_task(args, task_json, timeout_at):
+  try:
+    url = args.url.rstrip("/") + "/druid/indexer/v1/task"
+    req = urllib.request.Request(url, task_json.encode(), {'Content-Type' : 'application/json'})
+    add_basic_auth_header(args, req)
+    timeleft = timeout_at - time.time()
+    response_timeout = min(max(timeleft, 5), 10)
+    response = urllib.request.urlopen(req, None, response_timeout)
+    return response.read().rstrip()
+  except urllib.error.URLError as e:
+    if isinstance(e, urllib.error.HTTPError) and e.code >= 400 and e.code <= 500:
+      # 4xx (problem with the request) or 500 (something wrong on the server)
+      raise_friendly_error(e)
+    elif time.time() >= timeout_at:
+      # No futher retries
+      raise_friendly_error(e)
+    elif isinstance(e, urllib.error.HTTPError) and e.code in [301, 302, 303, 305, 307] and \
+        e.info().getheader("Location") is not None:
+      # Set the new location in args.url so it can be used by await_task_completion and re-issue the request
+      location = urllib.parse.urlparse(e.info().getheader("Location"))
+      args.url = "{0}://{1}".format(location.scheme, location.netloc)
+      sys.stderr.write("Redirect response received, setting url to [{0}]\n".format(args.url))
+      return post_task(args, task_json, timeout_at)
+    else:
+      # If at first you don't succeed, try, try again!
+      sleep_time = 5
+      if not args.quiet:
+        extra = ''
+        if hasattr(e, 'read'):
+          extra = e.read().rstrip()
+        sys.stderr.write("Waiting up to {0}s for indexing service [{1}] to become available. [Got: {2} {3}]".format(max(sleep_time, int(timeout_at - time.time())), args.url, str(e), extra).rstrip())
+        sys.stderr.write("\n")
+      time.sleep(sleep_time)
+      return post_task(args, task_json, timeout_at)
+
+# Keep trying until timeout_at, maybe die then
+def await_task_completion(args, task_id, timeout_at):
+  while True:
+    url = args.url.rstrip("/") + "/druid/indexer/v1/task/{0}/status".format(task_id)
+    req = urllib.request.Request(url)
+    add_basic_auth_header(args, req)
+    timeleft = timeout_at - time.time()
+    response_timeout = min(max(timeleft, 5), 10)
+    response = urllib.request.urlopen(req, None, response_timeout)
+    response_obj = json.loads(response.read())
+    response_status_code = response_obj["status"]["statusCode"]
+    if response_status_code in ['SUCCESS', 'FAILED']:
+      return response_status_code
+    else:
+      if time.time() < timeout_at:
+        if not args.quiet:
+          sys.stderr.write("Task {0} still running...\n".format(task_id))
+        timeleft = timeout_at - time.time()
+        time.sleep(min(5, timeleft))
+      else:
+        raise Exception("Task {0} did not finish in time!".format(task_id))
+
+def raise_friendly_error(e):
+  if isinstance(e, urllib.error.HTTPError):
+    text = e.read().strip()
+    reresult = re.search(r'<pre>(.*?)</pre>', text, re.DOTALL)
+    if reresult:
+      text = reresult.group(1).strip()
+    raise Exception("HTTP Error {0}: {1}, check overlord log for more details.\n{2}".format(e.code, e.reason, text))
+  raise e
+
+def await_load_completion(args, datasource, timeout_at):
+  while True:
+    url = args.coordinator_url.rstrip("/") + "/druid/coordinator/v1/loadstatus"
+    req = urllib.request.Request(url)
+    add_basic_auth_header(args, req)
+    timeleft = timeout_at - time.time()
+    response_timeout = min(max(timeleft, 5), 10)
+    response = urllib.request.urlopen(req, None, response_timeout)
+    response_obj = json.loads(response.read())
+    load_status = response_obj.get(datasource, 0.0)
+    if load_status >= 100.0:
+      sys.stderr.write("{0} loading complete! You may now query your data\n".format(datasource))
+      return
+    else:
+      if time.time() < timeout_at:
+        if not args.quiet:
+          sys.stderr.write("{0} is {1}% finished loading...\n".format(datasource, load_status))
+        timeleft = timeout_at - time.time()
+        time.sleep(min(5, timeleft))
+      else:
+        raise Exception("{0} was not loaded in time!".format(datasource))
+
+def main():
+  parser = argparse.ArgumentParser(description='Post Druid indexing tasks.')
+  parser.add_argument('--url', '-u', metavar='url', type=str, default='http://localhost:8090/', help='Druid Overlord url')
+  parser.add_argument('--coordinator-url', type=str, default='http://localhost:8081/', help='Druid Coordinator url')
+  parser.add_argument('--file', '-f', type=str, required=True, help='Query JSON file')
+  parser.add_argument('--submit-timeout', type=int, default=120, help='Timeout (in seconds) for submitting tasks')
+  parser.add_argument('--complete-timeout', type=int, default=14400, help='Timeout (in seconds) for completing tasks')
+  parser.add_argument('--load-timeout', type=int, default=14400, help='Timeout (in seconds) for waiting for tasks to load')
+  parser.add_argument('--quiet', '-q', action='store_true', help='Suppress retryable errors')
+  parser.add_argument('--user', type=str, default=None, help='Basic auth username')
+  parser.add_argument('--password', type=str, default=None, help='Basic auth password')
+  args = parser.parse_args()
+
+  submit_timeout_at = time.time() + args.submit_timeout
+  complete_timeout_at = time.time() + args.complete_timeout
+
+  task_contents = read_task_file(args)
+  task_json = json.loads(task_contents)
+  if task_json['type'] == "compact":
+    datasource = task_json['dataSource']
+  else:
+    datasource = json.loads(task_contents)["spec"]["dataSchema"]["dataSource"]
+  sys.stderr.write("Beginning indexing data for {0}\n".format(datasource))
+
+  task_id = json.loads(post_task(args, task_contents, submit_timeout_at))["task"]
+
+  sys.stderr.write('\033[1m' + "Task started: " + '\033[0m' + "{0}\n".format(task_id))
+  sys.stderr.write('\033[1m' + "Task log:     " + '\033[0m' + "{0}/druid/indexer/v1/task/{1}/log\n".format(args.url.rstrip("/"),task_id))
+  sys.stderr.write('\033[1m' + "Task status:  " + '\033[0m' + "{0}/druid/indexer/v1/task/{1}/status\n".format(args.url.rstrip("/"),task_id))
+
+  task_status = await_task_completion(args, task_id, complete_timeout_at)
+  sys.stderr.write("Task finished with status: {0}\n".format(task_status))
+  if task_status != 'SUCCESS':
+    sys.exit(1)
+
+  sys.stderr.write("Completed indexing data for {0}. Now loading indexed data onto the cluster...\n".format(datasource))
+  load_timeout_at = time.time() + args.load_timeout
+  await_load_completion(args, datasource, load_timeout_at)
+
+try:
+  main()
+except KeyboardInterrupt:
+  sys.exit(1)

--- a/docker/toolbox/Dockerfile
+++ b/docker/toolbox/Dockerfile
@@ -1,8 +1,31 @@
-FROM node:14.15.4
-ENV PATH="${PATH}:/usr/local/go/bin:/home/node/go/bin"
+#syntax=docker/dockerfile:1.2
+FROM ubuntu:20.04
+
 ENV CGO_ENABLED=0
-RUN apt-get install git curl && curl -O https://dl.google.com/go/go1.14.4.linux-amd64.tar.gz && tar -xvf go1.14.4.linux-amd64.tar.gz && chown -R root:root ./go && mv go /usr/local
-USER node
-RUN go get -u -d github.com/magefile/mage && cd ~/go/src/github.com/magefile/mage && go run bootstrap.go
+
+RUN apt -q update
+RUN apt -qy install \
+  bash build-essential curl git gnupg libssl-dev tar wget zlib1g-dev
+
+SHELL ["/usr/bin/bash", "-c"]
+
+RUN printf "%s\n" "source \$HOME/.asdf/asdf.sh" >> /root/.bashrc
+RUN printf "%s\n" "source \$HOME/.asdf/completions/asdf.bash" >> /root/.bashrc
+
+RUN git clone https://github.com/asdf-vm/asdf.git ~/.asdf --branch v0.8.0
+ENV PATH="/root/.asdf/shims:/root/.asdf/bin:${PATH}"
+
 WORKDIR /workspace
+
+RUN --mount=type=bind,source=.tool-versions,target=/workspace/.tool-versions \
+    --mount=type=bind,source=docker/toolbox/asdf-init.sh,target=/workspace/asdf-init.sh \
+    ./asdf-init.sh
+
+RUN printf "%s\n" "export GOPATH=\$(asdf where golang)/go" >> ~/.bashrc
+
+RUN --mount=type=bind,source=.tool-versions,target=/workspace/.tool-versions \
+  git clone https://github.com/magefile/mage /usr/local/mage \
+  && cd /usr/local/mage && source $HOME/.asdf/asdf.sh \
+  && GOPATH="$(asdf where golang)/go" go run bootstrap.go
+
 ENTRYPOINT ["tail", "-f"]

--- a/docker/toolbox/asdf-init.sh
+++ b/docker/toolbox/asdf-init.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+set -eo pipefail
+
+declare -r WORKSPACE="/workspace"
+declare -r TOOL_VERSIONS=".tool-versions"
+declare PLUGINS; PLUGINS="$(awk '{print $1}' "${WORKSPACE}/${TOOL_VERSIONS}")"
+
+plugin_installed() {
+  local plugin="${1}"
+
+  if asdf plugin list | grep -q "${plugin}"; then
+    return 0
+  fi
+
+  return 1
+}
+
+get_version() {
+  local tool="${1}"
+  local version
+  version="$(awk "/^${tool}/ {print \$2}" "${WORKSPACE}/${TOOL_VERSIONS}")"
+
+  printf "%s" "${version}"
+}
+
+version_installed() {
+  local tool="${1}"
+  local version
+  version="$(get_version "${tool}")"
+
+  if asdf list "${tool}" | grep -q "${version}"; then
+    return 0
+  fi
+
+  return 1
+}
+
+install() {
+  for plugin in ${PLUGINS}; do
+    if ! plugin_installed "${plugin}"; then
+      printf "Plugin %s not installed - installing\n" "${plugin}"
+      asdf plugin add "${plugin}"
+    fi
+
+    if ! version_installed "${plugin}"; then
+      local version; version="$(get_version "${plugin}")"
+      printf "%s version %s not installed - installing\n" "${plugin}" "${version}"
+      asdf install "${plugin}" "${version}"
+    fi
+  done
+
+  while read -r item; do
+    local plugin; plugin="$(printf "%s" "${item}" | awk '{print $1}')"
+    local version; version="$(printf "%s" "${item}" | awk '{print $2}')"
+    asdf global "${plugin}" "${version}"
+  done < "${WORKSPACE}/${TOOL_VERSIONS}"
+
+  asdf reshim
+
+  printf "All plugins installed\n"
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then install; fi

--- a/pkg/main.go
+++ b/pkg/main.go
@@ -8,12 +8,11 @@ import (
 )
 
 func main() {
-	// Start listening to requests send from Grafana. This call is blocking so
-	// it wont finish until Grafana shutsdown the process or the plugin choose
-	// to exit close down by itself
-	err := datasource.Serve(newDatasource())
-	// Log any error if we could start the plugin.
-	if err != nil {
+	// Start listening to requests sent from Grafana. This call is blocking so
+	// it won't finish until Grafana shuts down the process. or the plugin chooses
+	// to exit and close down by itself.
+	// Log any error if we could not start the plugin.
+	if err := datasource.Serve(newDatasource()); err != nil {
 		log.DefaultLogger.Error(err.Error())
 		os.Exit(1)
 	}

--- a/yarn.lock
+++ b/yarn.lock
@@ -10388,10 +10388,10 @@ rw@1:
   resolved "https://registry.yarnpkg.com/rw/-/rw-1.3.3.tgz#3f862dfa91ab766b14885ef4d01124bfda074fb4"
   integrity sha1-P4Yt+pGrdmsUiF700BEkv9oHT7Q=
 
-rxjs@6.6.3, rxjs@6.6.6, rxjs@^6.3.3, rxjs@^6.4.0, rxjs@^6.5.3:
-  version "6.6.6"
-  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.6.6.tgz#14d8417aa5a07c5e633995b525e1e3c0dec03b70"
-  integrity sha512-/oTwee4N4iWzAMAL9xdGKjkEHmIwupR3oXbQjCKywF1BeFohswF3vZdogbmEF6pZkOsXTzWkrZszrWpQTByYVg==
+rxjs@6.6.3, rxjs@^6.3.3, rxjs@^6.4.0, rxjs@^6.5.3:
+  version "6.6.3"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.6.3.tgz#8ca84635c4daa900c0d3967a6ee7ac60271ee552"
+  integrity sha512-trsQc+xYYXZ3urjOiJOuCOa5N3jAZ3eiSpQB5hIT8zGlL2QfnHLJ2r7GMkBGuIausdJN1OneaI6gQlsqNHHmZQ==
   dependencies:
     tslib "^1.9.0"
 


### PR DESCRIPTION
**Note:** this PR depends on https://github.com/grafadruid/druid-grafana/pull/56, so once it's merged the diff will shrink to only the changeset introduced by https://github.com/grafadruid/druid-grafana/commit/5470e787ff5955f7e7509e32cac97751e033af0d.

* Since the current toolbox container is based a Node.js base image,
  its build is specifically optimized to run Node.js (& ecosystem)
  applications & tools. Since there are tools in multiple languages that
  get run in the toolbox, it should instead be set up as a generic
  image with all necessary tools installed via ASDF, just as they are on
  the host system.
* Use an Ubuntu 20.04 LTS (Focal Fossa) image as base, and use ASDF to
  nstall all requisite languages: Node.js, Python, Golang. This allows
  the language installations to be exactly the same (or as close as
  possible, save the platform-specific differences).
* Additionally, add Python 3.9.2 to .tool-versions to make it managed by
  ASDF (just like the rest of the languages).
* Refactor provisioning logic a bit:
  * Check in post-index-task-main @ docker/provisioning/post-index-task
    to avoid having to fetch it every time
  * Migrate post-index-task to Python 3 with 2o3 (since Python 2 is EOL
    now)
  * Simplify provisioning logic in Magefile
* Small odds & ends