### PR TITLE
Optimize example data provisioning

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -2,3 +2,4 @@ source_up
 dotenv_if_exists .env
 export COMPOSE_DOCKER_CLI_BUILD=1
 export COMPOSE_FILE="${PWD}/docker/docker-compose.yml"
+export COMPOSE_PROJECT_NAME="druidgrafana"

--- a/docker/provisioning/post-index-task
+++ b/docker/provisioning/post-index-task
@@ -44,6 +44,40 @@ def add_basic_auth_header(args, req):
 
 # Keep trying until timeout_at, maybe die then
 def post_task(args, task_json, timeout_at):
+  max_retries = 10
+  retries = 0
+  task_parsed = json.loads(task_json)
+  while True:
+    try:
+      if task_parsed['type'] == "compact":
+        datasource = task_parsed['dataSource']
+      else:
+        datasource = task_parsed["spec"]["dataSchema"]["dataSource"]
+
+      if datasource in json.load(urllib.request.urlopen(args.broker_url.rstrip("/") + "/druid/v2/datasources")):
+        if not args.force:
+          sys.stderr.write("Datasource {0} alrady present - skipping (use -F/--force to ingest anyway)\n".format(datasource))
+          sys.exit(0)
+        else:
+          break
+
+      else:
+        break
+
+    except urllib.error.URLError as e:
+      if isinstance(e.reason, ConnectionRefusedError):
+        if retries <= max_retries:
+          retries += 1
+          sys.stderr.write("Waiting for broker to become available...\n")
+          time.sleep(5)
+          continue
+        else:
+          sys.stderr.write("Unable to get past error {0}. Please investigate.".format(e))
+          raise
+      else:
+        sys.stderr.write("Received unexpected error: {0}".format(e))
+        raise
+
   try:
     url = args.url.rstrip("/") + "/druid/indexer/v1/task"
     req = urllib.request.Request(url, task_json.encode(), {'Content-Type' : 'application/json'})
@@ -134,8 +168,10 @@ def await_load_completion(args, datasource, timeout_at):
 def main():
   parser = argparse.ArgumentParser(description='Post Druid indexing tasks.')
   parser.add_argument('--url', '-u', metavar='url', type=str, default='http://localhost:8090/', help='Druid Overlord url')
+  parser.add_argument('--broker-url', type=str, default='http://localhost:8082/', help='Druid Broker url')
   parser.add_argument('--coordinator-url', type=str, default='http://localhost:8081/', help='Druid Coordinator url')
   parser.add_argument('--file', '-f', type=str, required=True, help='Query JSON file')
+  parser.add_argument('--force', '-F', type=bool, default=False, help='Force index task even if datasource exists')
   parser.add_argument('--submit-timeout', type=int, default=120, help='Timeout (in seconds) for submitting tasks')
   parser.add_argument('--complete-timeout', type=int, default=14400, help='Timeout (in seconds) for completing tasks')
   parser.add_argument('--load-timeout', type=int, default=14400, help='Timeout (in seconds) for waiting for tasks to load')


### PR DESCRIPTION
**Note:** this PR depends on https://github.com/grafadruid/druid-grafana/pull/57, so once it's merged the diff will shrink to only the changeset introduced by https://github.com/grafadruid/druid-grafana/commit/4228ebabf675b97977997fbf64023c8ad151e192.

* Since the downloaded script (post-index-task-main from
  github.com/apache/druid) is indifferent to whether the data already
  exists, it proceeds to kick off indexing tasks every time mage
  env:start is invoked. This change adds support for checking for
  datasource presence in Druid, optimizing startup time on mage
  env:start if the data already exists.
* Since by default Docker Compose will use the directory that surrounds
  the docker-compose.yml file as the project name, the project name ends
  up being a generic one - "docker". Setting an explicit project name
  came be done via CLI (-p / --project-name) or the COMPOSE_PROJECT_NAME
  environment variable. To persist the project name across multiple
  Compose invocations, it is added to .envrc (direnv).
