### PR TITLE
Add support for "docker compose" in mage

### DIFF
--- a/Magefile.go
+++ b/Magefile.go
@@ -26,7 +26,7 @@ const (
 
 var (
 	useDocker          bool = os.Getenv("GRAFADRUID_USE_DOCKER") != "0"
-	useDockerComposeV2 bool = os.Getenv("GRAFADRUID_USE_DOCKER_COMPOSE_V2") != "0"
+	useDockerComposeV2 bool = os.Getenv("GRAFADRUID_USE_DOCKER_COMPOSE_V2") == "1"
 )
 
 func getDockerComposeCmdPrefix() []string {

--- a/Magefile.go
+++ b/Magefile.go
@@ -25,8 +25,8 @@ const (
 )
 
 var (
-	useDocker        bool     = os.Getenv("GRAFADRUID_USE_DOCKER") != "0"
-	useDockerComposeV2        bool     = os.Getenv("GRAFADRUID_USE_DOCKER_COMPOSE_V2") != "0"
+	useDocker           bool = os.Getenv("GRAFADRUID_USE_DOCKER") != "0"
+	useDockerComposeV2  bool = os.Getenv("GRAFADRUID_USE_DOCKER_COMPOSE_V2") != "0"
 )
 
 func getDockerComposeCmdPrefix() []string {

--- a/Magefile.go
+++ b/Magefile.go
@@ -25,8 +25,8 @@ const (
 )
 
 var (
-	useDocker           bool = os.Getenv("GRAFADRUID_USE_DOCKER") != "0"
-	useDockerComposeV2  bool = os.Getenv("GRAFADRUID_USE_DOCKER_COMPOSE_V2") != "0"
+	useDocker          bool = os.Getenv("GRAFADRUID_USE_DOCKER") != "0"
+	useDockerComposeV2 bool = os.Getenv("GRAFADRUID_USE_DOCKER_COMPOSE_V2") != "0"
 )
 
 func getDockerComposeCmdPrefix() []string {
@@ -37,7 +37,7 @@ func getDockerComposeCmdPrefix() []string {
 }
 
 func runDockerComposeCmd(cmd ...string) error {
-	var finalCmd = append(getDockerComposeCmdPrefix(), cmd...)
+	finalCmd := append(getDockerComposeCmdPrefix(), cmd...)
 	return sh.RunV(finalCmd[0], finalCmd[1:]...)
 }
 
@@ -66,7 +66,6 @@ func (e Env) Fmt() error {
 	); err != nil {
 		return err
 	}
-
 	return sh.RunV("yarn", "fmt")
 }
 
@@ -137,7 +136,7 @@ func (Frontend) Build() error {
 		return err
 	}
 	return runToolboxCmd("npx", "@grafana/toolkit@"+grafanaVersion, "plugin:build")
-	//return runToolboxCmd("npx", "@grafana/toolkit", "plugin:build", "--preserveConsole")
+	// return runToolboxCmd("npx", "@grafana/toolkit", "plugin:build", "--preserveConsole")
 }
 
 // Test runs frontend tests

--- a/pkg/druid.go
+++ b/pkg/druid.go
@@ -367,7 +367,8 @@ func (ds *druidDatasource) executeQuery(queryRef string, q druidquerybuilder.Que
 	detectColumnType := func(c *struct {
 		Name string
 		Type string
-	}, pos int, rr [][]interface{}) {
+	}, pos int, rr [][]interface{},
+	) {
 		t := map[string]int{"nil": 0}
 		for i := 0; i < len(rr); i += int(math.Ceil(float64(len(rr)) / 5.0)) {
 			r := rr[i]


### PR DESCRIPTION
`docker-compose` has now been replaced with `docker compose`. See https://stackoverflow.com/a/66516826 for a brief explanation.
On newer system, the existing mage commands dont work out of the box.
This PR updates the mage system to support either based on an environment flag.

Sample invocations on my system (only has `docker compose`, no `docker-compose`):

```
$ GRAFADRUID_USE_DOCKER_COMPOSE_V2=0 /home/azureuser/go/bin/mage env:restart
Error: failed to run "docker-compose down: exec: "docker-compose": executable file not found in $PATH"
```

```
$ GRAFADRUID_USE_DOCKER_COMPOSE_V2=1 /home/azureuser/go/bin/mage env:restart
[+] Running 10/10
 ⠿ Container druidgrafana-historical-1     Removed                                                                                                                                                                       0.6s
 ⠿ Container druidgrafana-router-1         Removed                                                                                                                                                                       0.7s
 ⠿ Container druidgrafana-grafana-1        Removed                                                                                                                                                                       0.4s
 ⠿ Container druidgrafana-toolbox-1        Removed                                                                                                                                                                      10.3s
 ⠿ Container druidgrafana-middlemanager-1  Removed                                                                                                                                                                       0.7s
 ⠿ Container druidgrafana-broker-1         Removed                                                                                                                                                                       0.5s
 ⠿ Container druidgrafana-coordinator-1    Removed                                                                                                                                                                       0.4s
 ⠿ Container druidgrafana-zookeeper-1      Removed                                                                                                                                                                       0.6s
 ⠿ Container druidgrafana-postgres-1       Removed                                                                                                                                                                       0.3s
 ⠿ Network druidgrafana_default            Removed                                                                                                                                                                       0.1s
WARN[0000] mount of type `volume` should not define `bind` option 
[+] Running 1/3
 ⠿ Network druidgrafana_default        Created                                                                                                                                                                           0.1s
[+] Running 3/3uidgrafana-zookeeper-1  Creating                                                                                                                                                                          0.1s
 ⠿ Network druidgrafana_default          Created                                                                                                                                                                         0.1s
 ⠿ Container druidgrafana-zookeeper-1    Created                                                                                                                                                                         0.2s
 ⠿ Container druidgrafana-postgres-1     Created                                                                                                                                                                         0.1s
 ⠋ Container druidgrafana-coordinator-1  Creating                                                                                                                                                                        0.1s
WARN[0000] mount of type `volume` should not define `bind` option 
[+] Running 10/10of type `volume` should not define `bind` option 
 ⠿ Network druidgrafana_default            Created                                                                                                                                                                       0.1s
 ⠿ Container druidgrafana-zookeeper-1      Started                                                                                                                                                                       1.1s
 ⠿ Container druidgrafana-postgres-1       Started                                                                                                                                                                       1.1s
 ⠿ Container druidgrafana-coordinator-1    Started                                                                                                                                                                       1.4s
 ⠿ Container druidgrafana-router-1         Started                                                                                                                                                                       2.5s
 ⠿ Container druidgrafana-toolbox-1        Started                                                                                                                                                                       2.3s
 ⠿ Container druidgrafana-historical-1     Started                                                                                                                                                                       2.3s
 ⠿ Container druidgrafana-middlemanager-1  Started                                                                                                                                                                       2.7s
 ⠿ Container druidgrafana-broker-1         Started                                                                                                                                                                       2.6s
 ⠿ Container druidgrafana-grafana-1        Started                                                                                                                                                                       3.1s

Ingesting example data into Druid
Beginning indexing data for wikipedia
Waiting for broker to become available...
Waiting for broker to become available...
Waiting for broker to become available...
Datasource wikipedia already present - skipping (use -F/--force to ingest anyway)

Druid: http://localhost:8888
Grafana: http://localhost:3000 (use druid/druid to login)
```