### PR TITLE
Support for repeat options

### DIFF
--- a/src/DruidDataSource.ts
+++ b/src/DruidDataSource.ts
@@ -1,4 +1,4 @@
-import { DataSourceInstanceSettings, MetricFindValue } from '@grafana/data';
+import { DataSourceInstanceSettings, MetricFindValue, ScopedVars } from '@grafana/data';
 import { DataSourceWithBackend, getTemplateSrv } from '@grafana/runtime';
 import { DruidSettings, DruidQuery } from './types';
 
@@ -11,7 +11,7 @@ export class DruidDataSource extends DataSourceWithBackend<DruidQuery, DruidSett
   filterQuery(query: DruidQuery) {
     return !query.hide;
   }
-  applyTemplateVariables(templatedQuery: DruidQuery) {
+  applyTemplateVariables(templatedQuery: DruidQuery, scopedVars?: ScopedVars) {
     const templateSrv = getTemplateSrv();
     let template = JSON.stringify({ ...templatedQuery, expr: undefined }).replace(
       druidVariableRegex,
@@ -22,7 +22,7 @@ export class DruidDataSource extends DataSourceWithBackend<DruidQuery, DruidSett
         return match;
       }
     );
-    return { ...JSON.parse(templateSrv.replace(template)), expr: templatedQuery.expr };
+    return { ...JSON.parse(templateSrv.replace(template, scopedVars)), expr: templatedQuery.expr };
   }
   async metricFindQuery(query: DruidQuery, options?: any): Promise<MetricFindValue[]> {
     return this.postResource('query-variable', this.applyTemplateVariables(query)).then((response) => {


### PR DESCRIPTION
When [repeat a panel](https://grafana.com/blog/2020/06/09/learn-grafana-how-to-automatically-repeat-rows-and-panels-in-dynamic-dashboards/), grafana-druid query does not split multiple variables.

For example, in the first SQL panel of Grafadruid Wikipedia Sample dashboard,  I selected multiple cities as variables and chose the variable in Repeat by variable under Repeat options.  Panels were automatically repeated, but the dataset did not.

<img width="438" alt="Screen Shot 2022-10-25 at 8 55 42 AM" src="https://user-images.githubusercontent.com/253408/197657592-a112df58-e943-47fb-883b-b5bd4aec0dad.png">

<img width="1179" alt="Screen Shot 2022-10-25 at 8 54 25 AM" src="https://user-images.githubusercontent.com/253408/197657563-97f697fe-cbb1-4539-9f58-3c20825bb7d8.png">

I found that scopedVars is used when repeat a panel or row,  it is passed to templateSrv replace method as local overrides.  So I add scopedVars as arguments in `DruidDataSource.applyTemplateVariables` method and pass it to the replace method.

![Screen Shot 2022-10-25 at 9 58 38 AM](https://user-images.githubusercontent.com/253408/197657727-7d5356dc-fa12-490f-bdb4-ca8ab098f251.png)



