### PR TITLE
Pass if the query doesn't have Builder or Settings

### DIFF
--- a/pkg/druid.go
+++ b/pkg/druid.go
@@ -392,6 +392,13 @@ func (ds *druidDatasource) prepareQuery(qry []byte, s *druidInstanceSettings) (d
 	if err != nil {
 		return nil, nil, err
 	}
+	if q.Builder == nil || q.Settings == nil {
+		// Don't return an error here, as this isn't a user error
+		// Grafana seems to invoke this even before the user has entered any query
+		log.DefaultLogger.Debug("Invalid query issued to Druid Plugin: missing builder or settings", "query:", string(qry))
+		return nil, nil, nil
+	}
+
 	var defaultQueryContext map[string]interface{}
 	if defaultContextParameters, ok := s.defaultQuerySettings["contextParameters"]; ok {
 		defaultQueryContext = ds.prepareQueryContext(defaultContextParameters.([]interface{}))


### PR DESCRIPTION
Why?
----
Sometime Grafana would invoke the plugin without the `Builder` or the `Settings` field. This usually happens before the user has entered any query at all.
In this case, we just pass the query evaluation.
Details on the bug can be found the below linked issue

The invalid query looks like this,
```
{
    "builder": null,
    "datasource": {
        "type": "grafadruid-druid-datasource",
        "uid": "P274814F1A96FB52D"
    },
    "datasourceId": 1,
    "expr": "{\"builder\":null,\"settings\":{}}",
    "intervalMs": 20000,
    "maxDataPoints": 1198,
    "refId": "A",
    "settings": {}
}
```

Issues Fixed
---
https://github.com/grafadruid/druid-grafana/issues/133

Testing
-----
- Mostly manually tested this. Here's the log I see when we hit an invalid query now.
```
logger=plugin.grafadruid-druid-datasource t=2023-01-24T14:46:45.6802033Z level=info msg="Invalid query issued to Druid Plugin: missing builder or settings" query:="{\"builder\":null,\"datasource\":{\"type\":\"grafadruid-druid-datasource\",\"uid\":\"P274814F1A96FB52D\"},\"datasourceId\":1,\"expr\":\"{\\\"builder\\\":null,\\\"settings\\\":{}}\",\"intervalMs\":20000,\"maxDataPoints\":1198,\"refId\":\"A\",\"settings\":{}}"

```
- Apart from this, I was able to run a successful build and test out panel creation and querying from the Grafana UI

Side note
-----
The build experience in this repo is very smooth. Kudos to the author!

