### PR TITLE
Simple log message changes

### DIFF
--- a/pkg/druid.go
+++ b/pkg/druid.go
@@ -172,7 +172,7 @@ type grafanaMetricFindValue struct {
 }
 
 func (ds *druidDatasource) QueryVariableData(ctx context.Context, req *backend.CallResourceRequest) ([]grafanaMetricFindValue, error) {
-	log.DefaultLogger.Info("QUERY VARIABLE", "_________________________REQ___________________________", string(req.Body))
+	log.DefaultLogger.Info("QUERY VARIABLE", "request", string(req.Body))
 	s, err := ds.settings(req.PluginContext)
 	if err != nil {
 		return []grafanaMetricFindValue{}, err
@@ -181,21 +181,21 @@ func (ds *druidDatasource) QueryVariableData(ctx context.Context, req *backend.C
 }
 
 func (ds *druidDatasource) queryVariable(qry []byte, s *druidInstanceSettings) ([]grafanaMetricFindValue, error) {
-	log.DefaultLogger.Info("DRUID EXECUTE QUERY VARIABLE", "_________________________GRAFANA QUERY___________________________", string(qry))
+	log.DefaultLogger.Info("DRUID EXECUTE QUERY VARIABLE", "grafana_query", string(qry))
 	// feature: probably implement a short (1s ? 500ms ? configurable in datasource ? beware memory: constrain size ?) life cache (druidInstanceSettings.cache ?) and early return then
 	response := []grafanaMetricFindValue{}
 	q, stg, err := ds.prepareQuery(qry, s)
 	if err != nil {
 		return response, err
 	}
-	log.DefaultLogger.Info("DRUID EXECUTE QUERY VARIABLE", "_________________________DRUID QUERY___________________________", q)
+	log.DefaultLogger.Info("DRUID EXECUTE QUERY VARIABLE", "druid_query", q)
 	r, err := ds.executeQuery("variable", q, s, stg)
 	if err != nil {
 		return response, err
 	}
-	log.DefaultLogger.Info("DRUID EXECUTE QUERY VARIABLE", "_________________________DRUID RESPONSE___________________________", r)
+	log.DefaultLogger.Info("DRUID EXECUTE QUERY VARIABLE", "druid_response", r)
 	response, err = ds.prepareVariableResponse(r, stg)
-	log.DefaultLogger.Info("DRUID EXECUTE QUERY VARIABLE", "_________________________GRAFANA RESPONSE___________________________", response)
+	log.DefaultLogger.Info("DRUID EXECUTE QUERY VARIABLE", "grafana_response", response)
 	return response, err
 }
 
@@ -308,7 +308,7 @@ func (ds *druidDatasource) settings(ctx backend.PluginContext) (*druidInstanceSe
 }
 
 func (ds *druidDatasource) query(qry backend.DataQuery, s *druidInstanceSettings) backend.DataResponse {
-	log.DefaultLogger.Info("DRUID EXECUTE QUERY", "_________________________GRAFANA QUERY___________________________", qry)
+	log.DefaultLogger.Info("DRUID EXECUTE QUERY", "grafana_query", qry)
 	rawQuery := interpolateVariables(string(qry.JSON), qry.Interval, qry.TimeRange.Duration())
 
 	// feature: probably implement a short (1s ? 500ms ? configurable in datasource ? beware memory: constrain size ?) life cache (druidInstanceSettings.cache ?) and early return then
@@ -318,19 +318,19 @@ func (ds *druidDatasource) query(qry backend.DataQuery, s *druidInstanceSettings
 		response.Error = err
 		return response
 	}
-	log.DefaultLogger.Info("DRUID EXECUTE QUERY", "_________________________DRUID QUERY___________________________", q)
+	log.DefaultLogger.Info("DRUID EXECUTE QUERY", "druid_query", q)
 	r, err := ds.executeQuery(qry.RefID, q, s, stg)
 	if err != nil {
 		response.Error = err
 		return response
 	}
-	log.DefaultLogger.Info("DRUID EXECUTE QUERY", "_________________________DRUID RESPONSE___________________________", r)
+	log.DefaultLogger.Info("DRUID EXECUTE QUERY", "druid_response", r)
 	response, err = ds.prepareResponse(r, stg)
 	if err != nil {
 		// note: error could be set from prepareResponse but this gives a chance to react to error here
 		response.Error = err
 	}
-	log.DefaultLogger.Info("DRUID EXECUTE QUERY", "_________________________GRAFANA RESPONSE___________________________", response)
+	log.DefaultLogger.Info("DRUID EXECUTE QUERY", "grafana_response", response)
 	return response
 }
 


### PR DESCRIPTION
Sometimes when you want to index logs, keys with "_________________________" make the process unpleasant.
This commit removes the excessive underscore usage