### PR TITLE
BUG FIX: String type columns typecasted as number

### DIFF
--- a/pkg/druid.go
+++ b/pkg/druid.go
@@ -520,8 +520,8 @@ func (ds *druidDatasource) executeQuery(queryRef string, q druidquerybuilder.Que
 				// len of sqlr > 1, we can infer string and number types from the data row (string is in "quotes") also, time is also in string format
 				switch sqlr[1].([]interface{})[i].(type) {
 				case string:
-					if col.Type != "time" {
-						// if the data type is string and not detected as time, keep it as string
+					if col.Type != "time" && col.Type != "bool" {
+						// if the data type is string and not detected as time or bool, keep it as string
 						col.Type = "string"
 					}
 				}

--- a/pkg/druid.go
+++ b/pkg/druid.go
@@ -517,6 +517,14 @@ func (ds *druidDatasource) executeQuery(queryRef string, q druidquerybuilder.Que
 					Type string
 				}{Name: c.(string)}
 				detectColumnType(&col, i, r.Rows)
+				// len of sqlr > 1, we can infer string and number types from the data row (string is in "quotes") also, time is also in string format
+				switch sqlr[1].([]interface{})[i].(type) {
+				case string:
+					if col.Type != "time" {
+						// if the data type is string and not detected as time, keep it as string
+						col.Type = "string"
+					}
+				}
 				r.Columns = append(r.Columns, col)
 			}
 		}


### PR DESCRIPTION
Issue
----
The column type is inferred in grafana plugin, by looking at the row values. So If a string type column which have all the column values as number digits, is treated as number in the plugin. This effects the alerting and overall experience for user.

#### `"id"` is of type string but have number values
<img width="1185" alt="Screenshot 2023-03-24 at 3 20 14 PM" src="https://user-images.githubusercontent.com/58038410/227504531-f016720c-1481-4feb-bf29-469154600210.png">

#### Grafana druid treating the column as number
<img width="1362" alt="Screenshot 2023-03-24 at 3 20 29 PM" src="https://user-images.githubusercontent.com/58038410/227504829-99af5c73-3b07-4b6c-a3a1-30f205d0d7ca.png">

Fix
---
This can be fixed as from druid client, strings come in "" (double quotes)
<img width="1228" alt="Screenshot 2023-03-24 at 3 28 08 PM" src="https://user-images.githubusercontent.com/58038410/227505307-0d47d2b1-68a3-46d6-a6f0-0b57d794d665.png">
