### PR TITLE
Fix error when first time chunk in topN is empty

### DIFF
--- a/pkg/druid.go
+++ b/pkg/druid.go
@@ -566,11 +566,13 @@ func (ds *druidDatasource) executeQuery(queryRef string, q druidquerybuilder.Que
 				for _, record := range result["result"].([]interface{}) {
 					var row []interface{}
 					row = append(row, result["timestamp"])
-					o := record.(map[string]interface{})
-					for _, c := range columns[1:] {
-						row = append(row, o[c])
+					o, ok := record.(map[string]interface{})
+					if ok {
+						for _, c := range columns[1:] {
+							row = append(row, o[c])
+						}
+						r.Rows = append(r.Rows, row)
 					}
-					r.Rows = append(r.Rows, row)
 				}
 			}
 			for i, c := range columns {

--- a/pkg/druid.go
+++ b/pkg/druid.go
@@ -554,12 +554,15 @@ func (ds *druidDatasource) executeQuery(queryRef string, q druidquerybuilder.Que
 	case "topN":
 		var tn []map[string]interface{}
 		err := json.Unmarshal(result, &tn)
-		if err == nil && len(tn) > 0 && len(tn[0]["result"].([]interface{})) > 0 {
-			columns := []string{"timestamp"}
-			for c := range tn[0]["result"].([]interface{})[0].(map[string]interface{}) {
-				columns = append(columns, c)
-			}
+		if err == nil && len(tn) > 0 {
+			var columns []string
 			for _, result := range tn {
+				if columns == nil && len(result["result"].([]interface{})) > 0 {
+					columns = append(columns, "timestamp")
+					for c := range result["result"].([]interface{})[0].(map[string]interface{}) {
+						columns = append(columns, c)
+					}
+				}
 				for _, record := range result["result"].([]interface{}) {
 					var row []interface{}
 					row = append(row, result["timestamp"])


### PR DESCRIPTION
# Summary of changes:
The old process is to check only the first item in the response to a topN query, expecting a "result" with one or more objects.
Instead, each item in the response is iterated through until one is found that has a result. This item is used to generate the columns. 


# Problem addressed
The existing algorithm for determining the columns in a topN query makes the incorrect assumption that the first result in the query will have data. The structure of a topN response is a list of time chunks, based on the granularity and intervals, within each chunk there may be between zero and `threshold` results.

Sample query using inline data:
```
{
  "queryType": "topN",
  "dataSource": {
    "type": "inline",
    "columnNames": ["__time","country", "city", "points", "potatoes","nothings"],
    "rows": [
      [1696549379001,"United States", "San Francisco", 5,null,null],
      [1696549379002,"Canada", "Calgary", 6, 3,null]
    ]
  },
    "aggregations": [
    {
      "type": "doubleSum",
      "name": "some_metric",
      "fieldName": "points"
    }],
  "dimension": "country",
  "metric": "some_metric",
  "threshold": 10,
  "granularity": "day",
  "intervals": ["2023-10-04/2023-10-06"]
}
```
Response:
```
[
  {
    "timestamp": "2023-10-04T00:00:00.000Z",
    "result": []
  },
  {
    "timestamp": "2023-10-05T00:00:00.000Z",
    "result": [
      {
        "country": "Canada",
        "some_metric": 6.0
      },
      {
        "country": "United States",
        "some_metric": 5.0
      }
    ]
  }
]
```

# Demonstration

This problem doesn't seem to appear with the sample dashboard using Wikipedia data, but that's because the example TopN query uses `All` granularity, which will ensure there is exactly one result in the response.
![image](https://github.com/grafadruid/druid-grafana/assets/7910938/ccd09ab7-b31b-47eb-ad79-e2c27d7ad50f)

To demonstrate the issue, I make the following changes:
Change granularity to `Minute` (I acknowledge this results in rather nonsensical results)
![image](https://github.com/grafadruid/druid-grafana/assets/7910938/4d25d528-16db-4256-86b6-48b9342dccd4)

With the default time range of:
`2016-06-26 16:47:04` to `2016-06-27 14:28:55`
the result is:
![image](https://github.com/grafadruid/druid-grafana/assets/7910938/988130d3-d01a-4a8a-8b07-3168f0dbd012)

But if the time range is changed to:
`2016-06-26 17:05:00` to `2016-06-27 14:28:55`
the result is:
![image](https://github.com/grafadruid/druid-grafana/assets/7910938/f5925b2a-32f1-4554-be4f-03a88992244a)

# after changes
After making the change to the algorithm, this time period produces results.
![image](https://github.com/grafadruid/druid-grafana/assets/7910938/ee134049-0b03-415b-b478-376805b2df17)

