### PR TITLE
Support timestamps with time zones enabled

### DIFF
--- a/docker/druid/environment
+++ b/docker/druid/environment
@@ -52,6 +52,9 @@ druid_processing_buffer_sizeBytes=17500000
 druid_processing_numThreads=1
 druid_processing_numMergeBuffers=1
 
+# Uncomment to enable timestamps with timezones
+# druid_sql_planner_sqlTimeZone="America/Los_Angeles"
+
 #Uncomment if authentication is required
 #druid_extensions_loadList=["druid-histogram", "druid-datasketches", "druid-lookups-cached-global", "postgresql-metadata-storage", "druid-basic-security"]
 #druid_auth_authenticatorChain=["MyBasicAuthenticator"]

--- a/pkg/druid.go
+++ b/pkg/druid.go
@@ -246,7 +246,7 @@ func (ds *druidDatasource) prepareVariableResponse(resp *druidResponse, settings
 				}
 				switch r[ic].(type) {
 				case string:
-					t, err = time.Parse("2006-01-02T15:04:05.000Z", r[ic].(string))
+					t, err = parseTime(r[ic].(string))
 					if err != nil {
 						t = time.Now()
 					}
@@ -459,7 +459,7 @@ func (ds *druidDatasource) executeQuery(queryRef string, q druidquerybuilder.Que
 				if err != nil {
 					_, err := strconv.ParseBool(v)
 					if err != nil {
-						_, err := time.Parse("2006-01-02T15:04:05.000Z", v)
+						_, err := parseTime(v)
 						if err != nil {
 							t["string"]++
 							continue
@@ -902,7 +902,7 @@ func (ds *druidDatasource) prepareResponse(resp *druidResponse, settings map[str
 				}
 				switch r[ic].(type) {
 				case string:
-					t, err := time.Parse("2006-01-02T15:04:05.000Z", r[ic].(string))
+					t, err := parseTime(r[ic].(string))
 					if err != nil {
 						t = time.Now()
 					}
@@ -975,4 +975,13 @@ func longToLog(longFrame *data.Frame, settings map[string]interface{}) (*data.Fr
 		logFrame.Fields = append(logFrame.Fields, f)
 	}
 	return logFrame, nil
+}
+
+// Parses timestamps of format ISO 8601 with and without timezone offset
+func parseTime(timeStr string) (time.Time, error) {
+	t, err := time.Parse("2006-01-02T15:04:05.000Z", timeStr)
+	if err == nil {
+		return t, nil
+	}
+	return time.Parse("2006-01-02T15:04:05.000-07:00", timeStr)
 }


### PR DESCRIPTION
If `sqlTimeZone` is passed in the query context or set in the Druid config, the plugin won't parse the timestamps correctly. 

If you try to graph the data with a time series panel, you'll get a "Data is missing a time field" error. 

I've included screenshots that show the format of the timestamps with and without the time zone offset and an example of the error you receive trying to graph data that contains timestamps with a time zone offset. 
 
<img width="907" alt="table-with-tz" src="https://github.com/user-attachments/assets/edfcd299-243b-4e98-aec4-2a6413c4b530" />
<img width="1724" alt="graph-with-tz-error" src="https://github.com/user-attachments/assets/922a38ef-53bf-41a0-bcf8-f77f3c8b001e" />
