### PR TITLE
chore: update CI to Node.js 20 and Go 1.24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,19 +11,19 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v5
 
       - name: Setup Node.js environment
-        uses: actions/setup-node@v2.1.2
+        uses: actions/setup-node@v5
         with:
-          node-version: '16.x'
+          node-version: '20'
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
+        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
 
       - name: Cache yarn cache
-        uses: actions/cache@v5
+        uses: actions/cache@v4
         id: cache-yarn-cache
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
@@ -32,7 +32,7 @@ jobs:
             ${{ runner.os }}-yarn-
       - name: Cache node_modules
         id: cache-node-modules
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: node_modules
           # yamllint disable-line rule:line-length
@@ -50,13 +50,13 @@ jobs:
         run: |
           if [ -f "Magefile.go" ]
           then
-            echo "::set-output name=has-backend::true"
+            echo "has-backend=true" >> $GITHUB_OUTPUT
           fi
       - name: Setup Go environment
         if: steps.check-for-backend.outputs.has-backend == 'true'
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v5
         with:
-          go-version: '1.18'
+          go-version: '1.24'
 
       - name: Test backend
         if: steps.check-for-backend.outputs.has-backend == 'true'


### PR DESCRIPTION
## Summary

Follow-up to v1.7.0 modernization - updates CI workflow to match project's current Node.js 20 and Go 1.24 versions.

## Changes

- Update `setup-node` to v5 with Node.js 20 (was v2.1.2 with Node.js 16)
- Update `setup-go` to v5 with Go 1.24 (was v2 with Go 1.18)
- Replace deprecated `::set-output` commands with `$GITHUB_OUTPUT`

## Context

v1.7.0 upgraded the project to Go 1.24.5 and Node.js 20 (#172, #174), but the CI workflow still referenced old versions.