### PR TITLE
fix: handle Druid type mismatches in prepareResponse without panicking

### DIFF
--- a/pkg/druid.go
+++ b/pkg/druid.go
@@ -920,33 +920,68 @@ func (ds *druidDatasource) prepareResponse(resp *druidResponse, settings map[str
 			}
 			switch c.Type {
 			case "string":
-				if r[ic] == nil {
-					r[ic] = ""
+				var s string
+				switch v := r[ic].(type) {
+				case nil:
+					s = ""
+				case string:
+					s = v
+				default:
+					s = fmt.Sprint(v)
 				}
-				ff = append(ff.([]string), r[ic].(string))
+				ff = append(ff.([]string), s)
 			case "float":
-				if r[ic] == nil {
-					r[ic] = 0.0
+				var f float64
+				switch v := r[ic].(type) {
+				case nil:
+					f = 0
+				case float64:
+					f = v
+				case float32:
+					f = float64(v)
+				case int:
+					f = float64(v)
+				case int64:
+					f = float64(v)
+				case string:
+					f, _ = strconv.ParseFloat(v, 64)
 				}
-				ff = append(ff.([]float64), r[ic].(float64))
+				ff = append(ff.([]float64), f)
 			case "int":
-				if r[ic] == nil {
-					r[ic] = "0"
-				}
-				i, err := strconv.Atoi(r[ic].(string))
-				if err != nil {
+				var i int64
+				switch v := r[ic].(type) {
+				case nil:
 					i = 0
+				case int64:
+					i = v
+				case int:
+					i = int64(v)
+				case float64:
+					i = int64(v)
+				case float32:
+					i = int64(v)
+				case string:
+					n, err := strconv.Atoi(v)
+					if err == nil {
+						i = int64(n)
+					}
 				}
-				ff = append(ff.([]int64), int64(i))
+				ff = append(ff.([]int64), i)
 			case "bool":
 				var b bool
-				var err error
-				b, ok := r[ic].(bool)
-				if !ok {
-					b, err = strconv.ParseBool(r[ic].(string))
-					if err != nil {
-						b = false
-					}
+				switch v := r[ic].(type) {
+				case nil:
+					b = false
+				case bool:
+					b = v
+				case string:
+					b, _ = strconv.ParseBool(v)
+				case float64:
+					b = v != 0
+				case int:
+					b = v != 0
+				case int64:
+					b = v != 0
 				}
 				ff = append(ff.([]bool), b)
 			case "nil":


### PR DESCRIPTION
## Summary

`prepareResponse` (`pkg/druid.go`) used unchecked type assertions (`r[ic].(string)`, `r[ic].(float64)`, …) inside the per-column switch on the metadata type. When Druid returned a value whose JSON type did not match the column's declared type — e.g. a numeric value in a column tagged `"string"`, which happens for some Timeseries / aggregation responses on recent Druid versions — the goroutine panicked with:

```
panic: interface conversion: interface {} is float64, not string
```

The plugin then returned a 500 from `/api/ds/query`, and the panel showed *No data*.

This change replaces the unchecked assertions with type switches that coerce gracefully:

| Column type | Accepts | Fallback |
|---|---|---|
| `string` | any (`fmt.Sprint`) | `""` if nil |
| `float`  | `float32/64`, `int`, `int64`, parsed `string` | `0` |
| `int`    | `int`, `int64`, `float32/64`, parsed `string` | `0` |
| `bool`   | `bool`, parsed `string`, numeric (0 → false) | `false` |

The `nil` and `time` branches already used safe forms and are untouched.

## Reproduction / verification

Reproduced against the bundled `Grafadruid Wikipedia Sample` dashboard on Grafana 13.0.1 + Druid 33.0.0:

1. `docker compose up --build` (with `GRAFANA_VERSION=13.0.1`)
2. Open the dashboard's `TIMESERIES` panel → 500 from `/api/ds/query`, Grafana log contains the panic + full goroutine stack pointing at `pkg/druid.go:926`.
3. Apply this patch, `mage sdk:build:linux`, `docker restart …grafana…`.
4. Reload the dashboard → `TIMESERIES` panel renders, browser console clean (0 errors / 0 warnings), Grafana log has no plugin panics.
